### PR TITLE
linter: handles `empty` and `double_dispose` examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,12 @@ target_link_libraries(ast_has_var PUBLIC
     ast_expressions
 )
 
+add_component(ast_collect_vars src/ast/collect_vars)
+target_link_libraries(ast_collect_vars PUBLIC
+    CONAN_PKG::gsl-lite
+    ast_expressions
+)
+
 add_component(ast_statements src/ast/statements)
 target_link_libraries(ast_statements PUBLIC
     CONAN_PKG::gsl-lite
@@ -72,6 +78,7 @@ target_link_libraries(address_expr_collector PUBLIC
     ast_manager
     ast_statements
     ast_expressions
+    ast_collect_vars
 )
 
 add_component(linter_configuration src/linter/configuration)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,56 +21,59 @@ set(BUILD_PLUGIN ON CACHE BOOL "Try to find LLVM and build clang plugin")
 ## Defining libraries
 ##
 
-add_component(util_for_each_argument
-    HEADER src/util/for_each_argument.hpp)
+add_component(util_for_each_argument src/util/for_each_argument)
 target_link_libraries(util_for_each_argument INTERFACE CONAN_PKG::boost)
 
-add_component(util_unique_from_ref
-    HEADER src/util/make_unique_from_ref.hpp)
+add_component(util_unique_from_ref src/util/make_unique_from_ref)
 
-add_component(util_indent_text
-    HEADER src/util/indent_text.hpp
-    IMPL src/util/indent_text.cpp)
+add_component(util_indent_text src/util/indent_text)
 
-add_component(ast_manager
-    HEADER src/ast/manager.hpp
-    IMPL src/ast/manager.cpp)
+add_component(ast_manager src/ast/manager)
 
-add_component(ast_expressions
-    HEADER src/ast/expressions.hpp
-    IMPL src/ast/expressions.cpp
-    TEST src/ast/expressions.test.cpp)
-target_link_libraries(ast_expressions PUBLIC CONAN_PKG::boost ast_manager)
+add_component(ast_expressions src/ast/expressions)
+target_link_libraries(ast_expressions PUBLIC
+    CONAN_PKG::boost
+    ast_manager
+)
 
-add_component(ast_replace_var
-    HEADER src/ast/replace_var.hpp
-    IMPL src/ast/replace_var.cpp
-    TEST src/ast/replace_var.test.cpp)
-target_link_libraries(ast_replace_var PUBLIC CONAN_PKG::boost ast_manager ast_expressions)
+add_component(ast_replace_var src/ast/replace_var)
+target_link_libraries(ast_replace_var PUBLIC
+    CONAN_PKG::boost
+    ast_manager
+    ast_expressions
+)
 
-add_component(ast_statements
-    HEADER src/ast/statements.hpp
-    IMPL src/ast/statements.cpp
-    TEST src/ast/statements.test.cpp)
-target_link_libraries(ast_statements PUBLIC CONAN_PKG::gsl-lite util_for_each_argument util_indent_text ast_manager ast_expressions)
+add_component(ast_statements src/ast/statements)
+target_link_libraries(ast_statements PUBLIC
+    CONAN_PKG::gsl-lite
+    util_for_each_argument
+    util_indent_text
+    ast_manager
+    ast_expressions
+)
 
-add_component(constraint_set
-    HEADER src/constraint/set.hpp
-    IMPL src/constraint/set.cpp
-    TEST src/constraint/set.test.cpp)
-target_link_libraries(constraint_set PUBLIC CONAN_PKG::gsl-lite CONAN_PKG::z3 ast_expressions)
+add_component(constraint_set src/constraint/set)
+target_link_libraries(constraint_set PUBLIC
+    CONAN_PKG::gsl-lite
+    CONAN_PKG::z3
+    ast_expressions
+)
 
-add_component(address_expr_collector
-    HEADER src/linter/address_expr_collector.hpp
-    IMPL src/linter/address_expr_collector.cpp
-    TEST src/linter/address_expr_collector.test.cpp)
-target_link_libraries(address_expr_collector PUBLIC CONAN_PKG::gsl-lite ast_manager ast_statements ast_expressions)
+add_component(address_expr_collector src/linter/address_expr_collector)
+target_link_libraries(address_expr_collector PUBLIC
+    CONAN_PKG::gsl-lite
+    ast_manager
+    ast_statements
+    ast_expressions
+)
 
-add_component(linter
-    HEADER src/linter/linter.hpp
-    IMPL src/linter/linter.cpp
-    TEST src/linter/linter.test.cpp)
-target_link_libraries(linter PUBLIC ast_manager ast_statements ast_expressions address_expr_collector)
+add_component(linter src/linter/linter)
+target_link_libraries(linter PUBLIC
+    ast_manager
+    ast_statements
+    ast_expressions
+    address_expr_collector
+)
 
 ## 
 ## LLVM setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(address_expr_collector PUBLIC
 
 add_component(linter_configuration src/linter/configuration)
 target_link_libraries(linter_configuration PUBLIC
+    CONAN_PKG::spdlog
     ast_manager
     ast_statements
     ast_has_var
@@ -85,6 +86,7 @@ target_link_libraries(linter_configuration PUBLIC
 
 add_component(linter src/linter/linter)
 target_link_libraries(linter PUBLIC
+    CONAN_PKG::spdlog
     ast_manager
     ast_statements
     ast_expressions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ target_link_libraries(ast_replace_var PUBLIC
     ast_expressions
 )
 
+add_component(ast_replace_var src/ast/has_var)
+target_link_libraries(ast_has_var PUBLIC
+    CONAN_PKG::boost
+    ast_manager
+    ast_expressions
+)
+
 add_component(ast_statements src/ast/statements)
 target_link_libraries(ast_statements PUBLIC
     CONAN_PKG::gsl-lite
@@ -79,6 +86,8 @@ target_link_libraries(linter PUBLIC
     ast_manager
     ast_statements
     ast_expressions
+    ast_replace_var
+    ast_has_var
     address_expr_collector
     linter_configuration
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,20 @@ target_link_libraries(address_expr_collector PUBLIC
     ast_expressions
 )
 
+add_component(linter_configuration src/linter/configuration)
+target_link_libraries(linter_configuration PUBLIC
+    ast_manager
+    ast_statements
+    constraint_set
+)
+
 add_component(linter src/linter/linter)
 target_link_libraries(linter PUBLIC
     ast_manager
     ast_statements
     ast_expressions
     address_expr_collector
+    linter_configuration
 )
 
 ## 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(ast_replace_var PUBLIC
     ast_expressions
 )
 
-add_component(ast_replace_var src/ast/has_var)
+add_component(ast_has_var src/ast/has_var)
 target_link_libraries(ast_has_var PUBLIC
     CONAN_PKG::boost
     ast_manager
@@ -78,6 +78,8 @@ add_component(linter_configuration src/linter/configuration)
 target_link_libraries(linter_configuration PUBLIC
     ast_manager
     ast_statements
+    ast_has_var
+    ast_replace_var
     constraint_set
 )
 
@@ -87,7 +89,6 @@ target_link_libraries(linter PUBLIC
     ast_statements
     ast_expressions
     ast_replace_var
-    ast_has_var
     address_expr_collector
     linter_configuration
 )

--- a/cmake/components.cmake
+++ b/cmake/components.cmake
@@ -22,6 +22,26 @@ function(add_component name)
     set(multi_value_keywords)
     cmake_parse_arguments(PARSE_ARGV 1 file "${options}" "${one_value_keywords}" "${multi_value_keywords}")
 
+    if (NOT DEFINED file_HEADER AND
+        NOT DEFINED file_IMPL AND
+        NOT DEFINED file_TEST AND
+        DEFINED file_UNPARSED_ARGUMENTS)
+
+        list(GET file_UNPARSED_ARGUMENTS 0 root_path)
+
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${root_path}.hpp")
+            set(file_HEADER "${root_path}.hpp")
+        endif()
+
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${root_path}.cpp")
+            set(file_IMPL "${root_path}.cpp")
+        endif()
+
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${root_path}.test.cpp")
+            set(file_TEST "${root_path}.test.cpp")
+        endif()
+    endif()
+
     if(NOT DEFINED file_HEADER)
         message(FATAL "add_component: HEADER argument missing. add_component should always be called with the HEADER and TEST arguments. Example: add_component(foo HEADER foo.h IMPL foo.cpp TEST foo.test.cpp)")
     endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,6 +2,7 @@
 gsl-lite/0.40.0
 boost/1.78.0
 z3/4.8.8
+spdlog/1.10.0
 
 [generators]
 cmake

--- a/src/ast/collect_vars.cpp
+++ b/src/ast/collect_vars.cpp
@@ -1,0 +1,65 @@
+#include <ast/collect_vars.hpp>
+
+#include <gsl/gsl-lite.hpp>
+
+struct var_collector : public ast::expression_visitor
+{
+    void process(ast::expression& expr) override
+    {
+        throw std::runtime_error("var_collector: encountered an unknown statement type (" + expr.to_string() + ")");
+    }
+
+    void process(ast::var& var) override
+    {
+        vars_.push_back(&var);
+    }
+
+    void process(ast::integer& number) override
+    {
+        // Do nothing
+    }
+
+    void process(ast::add& sum) override
+    {
+        sum.left()->accept(*this);
+        sum.right()->accept(*this);
+    }
+
+    void process(ast::multiply& product) override
+    {
+        product.left()->accept(*this);
+        product.right()->accept(*this);
+    }
+
+    void process(ast::constraint& constraint) override
+    {
+        // TODO: maybe redirect by default?
+        process(static_cast<ast::expression&>(constraint));
+    }
+
+    gsl::span<ast::var*> vars()
+    {
+        return vars_;
+    }
+
+    std::vector<ast::var*> move_vars()
+    {
+        return std::move(vars_);
+    }
+
+private:
+    std::vector<ast::var*> vars_;
+};
+
+namespace ast
+{
+
+std::vector<ast::var*> collect_vars(ast::expression* root)
+{
+    var_collector collector;
+    root->accept(collector);
+
+    return collector.move_vars();
+}
+
+}

--- a/src/ast/collect_vars.hpp
+++ b/src/ast/collect_vars.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <ast/expressions.hpp>
+
+#include <vector>
+
+namespace ast
+{
+
+std::vector<ast::var*> collect_vars(ast::expression* root);
+
+}

--- a/src/ast/has_var.cpp
+++ b/src/ast/has_var.cpp
@@ -1,0 +1,59 @@
+#include <ast/expressions.hpp>
+#include <ast/manager.hpp>
+#include <ast/has_var.hpp>
+
+namespace ast
+{
+
+struct has_var_visitor : public ast::expression_visitor
+{
+    has_var_visitor(ast::var* target) :
+        target_(target)
+    {}
+
+    void process(ast::expression& expr) override
+    {
+        result = false;
+    }
+
+    void process(ast::var& var) override
+    {
+        result = (var.name() == target_->name());
+    }
+
+    void process(ast::integer& integer) override
+    {
+        result = false;
+    }
+
+    void process(ast::add& sum) override
+    {
+        result = (has_var(sum.left(), target_) || has_var(sum.right(), target_));
+    }
+
+    void process(ast::multiply& product) override
+    {
+        result = (has_var(product.left(), target_) || has_var(product.right(), target_));
+    }
+
+    void process(ast::constraint& c) override
+    {
+        result = (has_var(c.left(), target_) || has_var(c.right(), target_));
+
+    }
+
+    bool result;
+
+private:
+    ast::var* target_;
+};
+
+bool has_var(ast::expression* expr, ast::var* target)
+{
+    has_var_visitor visitor(target);
+    expr->accept(visitor);
+
+    return visitor.result;
+}
+
+}

--- a/src/ast/has_var.hpp
+++ b/src/ast/has_var.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ast/manager.hpp>
+#include <ast/expressions.hpp>
+
+namespace ast
+{
+
+bool has_var(ast::expression* expr, ast::var* target);
+
+}

--- a/src/ast/replace_var.cpp
+++ b/src/ast/replace_var.cpp
@@ -1,5 +1,5 @@
-#include "ast/expressions.hpp"
-#include "ast/manager.hpp"
+#include <ast/expressions.hpp>
+#include <ast/manager.hpp>
 #include <ast/replace_var.hpp>
 
 namespace ast

--- a/src/ast/statements.hpp
+++ b/src/ast/statements.hpp
@@ -73,6 +73,11 @@ struct assign final : public visitable_statement<assign>
         dest_(store.make_expression<ast::var>(varName)), expr_(store.acquire_expression(std::forward<Expression>(expr)))
     {}
 
+    template <class Expression>
+    assign(manager& store, const std::string& varName, Expression* expr) :
+        dest_(store.make_expression<ast::var>(varName)), expr_(expr)
+    {}
+
     std::string to_string() const override
     {
         return dest_->to_string() + " := " + expr_->to_string() + "\n";

--- a/src/constraint/set.cpp
+++ b/src/constraint/set.cpp
@@ -9,6 +9,18 @@
 namespace constraint
 {
 
+std::string set::to_string() const
+{
+    std::string text;
+    for (const auto& c : constraints_)
+    {
+        text += c->to_string();
+        text += "\n";
+    }
+
+    return text;
+}
+
 void set::add(ast::constraint* expr)
 {
     constraints_.push_back(expr);

--- a/src/constraint/set.hpp
+++ b/src/constraint/set.hpp
@@ -3,6 +3,7 @@
 #include <ast/expressions.hpp>
 
 #include <z3++.h>
+#include <gsl/gsl-lite.hpp>
 
 #include <string>
 
@@ -16,6 +17,10 @@ struct set
     bool check_consistency() const;
 
     std::string to_string() const;
+
+    gsl::span<ast::constraint*> get() {
+        return constraints_;
+    }
 
 private:
     std::vector<ast::constraint*> constraints_;

--- a/src/constraint/set.hpp
+++ b/src/constraint/set.hpp
@@ -4,6 +4,8 @@
 
 #include <z3++.h>
 
+#include <string>
+
 namespace constraint
 {
 
@@ -12,6 +14,8 @@ struct set
     void add(ast::constraint*);
     bool check_satisfiability_of(ast::constraint*) const;
     bool check_consistency() const;
+
+    std::string to_string() const;
 
 private:
     std::vector<ast::constraint*> constraints_;

--- a/src/linter/configuration.cpp
+++ b/src/linter/configuration.cpp
@@ -77,6 +77,32 @@ std::vector<ast::expression*> configuration::current_address_exprs(ast::manager&
 }
 
 bool configuration::check_reachability_from(ast::manager& store, ast::var* from, ast::expression* to)
+{
+    auto currentExprs = current_address_exprs(store);
+
+    bool hasLeak = false;
+    for (auto& e1 : currentExprs)
+    {
+        bool reachable = true;
+        for (auto& e2 : currentExprs)
+        {
+            auto e2Replaced = ast::replace_var(store, e2, from, to);
+            auto eq = store.make_expression<ast::constraint>(
+                ast::constraint::relation::eq, e1, e2Replaced
+            );
+
+            bool result = constraints_.check_satisfiability_of(eq);
+            std::cout << "        Checking reachibility of " << eq->to_string() << " :: " << !result << "\n";
+
+            reachable = reachable && !result;
+            if (!reachable)
+                break;
+        }
+
+        if (!reachable)
+            return false;
+    }
+
     return true;
 }
 

--- a/src/linter/configuration.cpp
+++ b/src/linter/configuration.cpp
@@ -5,6 +5,7 @@
 #include <ast/has_var.hpp>
 #include <linter/linter.hpp>
 #include <linter/configuration.hpp>
+#include <spdlog/spdlog.h>
 
 namespace linter
 {
@@ -93,7 +94,7 @@ bool configuration::check_reachability_from(ast::manager& store, ast::var* from,
             );
 
             bool result = constraints_.check_satisfiability_of(eq);
-            std::cout << "        Checking reachibility of " << eq->to_string() << " :: " << !result << "\n";
+            spdlog::trace("        Checking reachibility of {} :: {}", eq->to_string(), !result);
 
             reachable = reachable && !result;
             if (!reachable)

--- a/src/linter/configuration.cpp
+++ b/src/linter/configuration.cpp
@@ -1,0 +1,66 @@
+#include <linter/configuration.hpp>
+
+namespace linter
+{
+
+std::string configuration::to_string() const
+{
+    std::string text;
+    text += "Current vars: ";
+    for (const auto& name : currentVars_)
+    {
+        if (name != *currentVars_.begin())
+        {
+            text += ", ";
+        }
+
+        text += name;
+    }
+
+    text += "\n";
+    text += "Current expressions: ";
+    for (const auto& expr : currentAddressExprs_)
+    {
+        if (expr != *currentAddressExprs_.begin())
+        {
+            text += ", ";
+        }
+
+        text += expr->to_string();
+    }
+
+    text += "\n";
+    text += "Constraints:\n";
+    text += constraints_.to_string();
+
+    return text;
+}
+
+bool configuration::check_reachability_from(const configuration& old) const
+{
+    return true;
+}
+
+bool configuration::add_var(ast::var* var)
+{
+    currentVars_.insert(var->name());
+    return true;
+}
+
+bool configuration::remove_var(ast::var* var)
+{
+    currentVars_.erase(var->name());
+    return true;
+}
+
+void configuration::add_array_constraints_for(ast::var*, size_t elemCount)
+{
+
+}
+
+void configuration::replace(ast::var* from, ast::expression* to)
+{
+
+}
+
+}

--- a/src/linter/configuration.cpp
+++ b/src/linter/configuration.cpp
@@ -85,7 +85,7 @@ bool configuration::check_reachability_from(ast::manager& store, ast::var* from,
     bool hasLeak = false;
     for (auto& e1 : currentExprs)
     {
-        bool reachable = true;
+        bool reachable = false;
         for (auto& e2 : currentExprs)
         {
             auto e2Replaced = ast::replace_var(store, e2, from, to);
@@ -93,19 +93,23 @@ bool configuration::check_reachability_from(ast::manager& store, ast::var* from,
                 ast::constraint::relation::eq, e1, e2Replaced
             );
 
-            bool result = constraints_.check_satisfiability_of(eq);
-            spdlog::trace("        Checking reachibility of {} :: {}", eq->to_string(), !result);
+            reachable = constraints_.check_satisfiability_of(eq);
+            spdlog::trace("        Checking reachibility of {} :: {}", eq->to_string(), reachable);
 
-            reachable = reachable && !result;
-            if (!reachable)
+            if (reachable)
                 break;
         }
 
+        spdlog::trace("old expression {} is reachable? {}", e1->to_string(), reachable);
+
+        hasLeak = hasLeak || !reachable;
+        /*
         if (!reachable)
             return false;
+            */
     }
 
-    return true;
+    return !hasLeak; //true;
 }
 
 bool configuration::add_var(ast::var* var)

--- a/src/linter/configuration.hpp
+++ b/src/linter/configuration.hpp
@@ -22,10 +22,24 @@ struct configuration
 
     std::string to_string() const;
 
+    const constraint::set& constraints() const {
+        return constraints_;
+    }
+
+    void constraints(const constraint::set& set) {
+        constraints_ = set;
+    }
+
+    const std::set<std::string>& current_vars()
+    {
+        return currentVars_;
+    }
+
 private:
     std::set<std::string> currentVars_;
     std::set<ast::expression*> currentAddressExprs_;
     constraint::set constraints_;
+
     std::vector<ast::expression*> current_address_exprs(ast::manager& store);
 };
 

--- a/src/linter/configuration.hpp
+++ b/src/linter/configuration.hpp
@@ -13,11 +13,11 @@ namespace linter
 struct configuration
 {
 
-    bool check_reachability_from(const configuration& old) const;
+    bool check_reachability_from(ast::manager& store, ast::var* from, ast::expression* to) /*const*/;
 
     bool add_var(ast::var*);
     bool remove_var(ast::var*);
-    void add_array_constraints_for(ast::var*, size_t elemCount);
+    void add_array_constraints_for(ast::manager&, ast::var*, size_t elemCount);
     void replace(ast::var* from, ast::expression* to);
 
     std::string to_string() const;
@@ -26,6 +26,7 @@ private:
     std::set<std::string> currentVars_;
     std::set<ast::expression*> currentAddressExprs_;
     constraint::set constraints_;
+    std::vector<ast::expression*> current_address_exprs(ast::manager& store);
 };
 
 }

--- a/src/linter/configuration.hpp
+++ b/src/linter/configuration.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <ast/manager.hpp>
+#include <ast/expressions.hpp>
+#include <constraint/set.hpp>
+
+#include <set>
+#include <string>
+
+namespace linter
+{
+
+struct configuration
+{
+
+    bool check_reachability_from(const configuration& old) const;
+
+    bool add_var(ast::var*);
+    bool remove_var(ast::var*);
+    void add_array_constraints_for(ast::var*, size_t elemCount);
+    void replace(ast::var* from, ast::expression* to);
+
+    std::string to_string() const;
+
+private:
+    std::set<std::string> currentVars_;
+    std::set<ast::expression*> currentAddressExprs_;
+    constraint::set constraints_;
+};
+
+}

--- a/src/linter/linter.cpp
+++ b/src/linter/linter.cpp
@@ -1,8 +1,96 @@
-#include "ast/expressions.hpp"
-#include "ast/statements.hpp"
+#include <ast/statements.hpp>
 #include <linter/linter.hpp>
 
 namespace linter
 {
+
+struct linter_visitor : public ast::statement_visitor
+{
+    linter_visitor(linter& linter) :
+        linter_(linter)
+    {}
+
+    void process(ast::statement&) override
+    {
+
+    }
+
+    void process(ast::block& block) override
+    {
+
+    }
+
+    void process(ast::decl& decl) override
+    {
+        // Add a variable to configuration
+        // Magic + variable -> expr in set...
+        // replace all variables with the expression
+        //
+        // decl DOES NOT create new address variables!
+        //
+        // Hmm... So, when we declare variable, the replacement affects
+        // the constraint set only if the variable was declared prior.
+
+    }
+
+    void process(ast::assign& assignment) override
+    {
+        // Skip, if the variable does not influence the pointers.
+        // TODO
+
+        // Required: just replace the variable with expression
+        
+        // BONUS: check reachability
+    }
+
+    void process(ast::alloc& alloc) override
+    {
+        // TODO: find out what proveFrom means
+
+        // Required: replace var with a temporary
+        // Maybe: amend current address expressions
+
+
+
+    }
+
+    void process(ast::store&) override
+    {
+        // Identity???
+    }
+
+    void process(ast::load&) override
+    {
+
+    }
+
+    void process(ast::dispose& dispose) override
+    {
+        // Check if in current address variables
+
+        // Required: remove var...
+    }
+
+    void process(ast::if_else&) override
+    {
+
+    }
+
+    void process(ast::while_loop&) override
+    {
+
+    }
+
+private:
+    linter& linter_;
+};
+
+void linter::process(ast::block& block)
+{
+    block.accept(exprStat_);
+
+    linter_visitor v(*this);
+    block.accept(v);
+}
 
 }

--- a/src/linter/linter.cpp
+++ b/src/linter/linter.cpp
@@ -41,6 +41,12 @@ struct linter_visitor : public ast::statement_visitor
         // the constraint set only if the variable was declared prior.
 
         linter_.cnf_.add_var(decl.variable());
+
+        auto assignmentPart = linter_.astStore_.make_statement<ast::assign>(
+            decl.variable()->name(), decl.value()
+        );
+
+        assignmentPart->accept(*this);
     }
 
     void process(ast::assign& assignment) override
@@ -97,7 +103,7 @@ struct linter_visitor : public ast::statement_visitor
         auto reachable = linter_.cnf_.check_reachability_from(linter_.astStore_, assignment.destination(), assignment.value());
         if (!reachable)
         {
-            spdlog::error("Memory leak detected");
+            spdlog::debug("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Memory leak detected");
         }
         
         linter_.cnf_.constraints(newSet);
@@ -185,7 +191,7 @@ struct linter_visitor : public ast::statement_visitor
         bool removed = linter_.cnf_.remove_var(dispose.target_var());
         if (!removed)
         {
-            spdlog::error("Double free of {}", dispose.target_var()->name());
+            spdlog::debug("!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Double free of {}", dispose.target_var()->name());
         }
     }
 

--- a/src/linter/linter.cpp
+++ b/src/linter/linter.cpp
@@ -1,4 +1,8 @@
+#include <ast/expressions.hpp>
+#include <ast/manager.hpp>
+#include <ast/replace_var.hpp>
 #include <ast/statements.hpp>
+#include <iomanip>
 #include <linter/linter.hpp>
 
 namespace linter
@@ -17,7 +21,13 @@ struct linter_visitor : public ast::statement_visitor
 
     void process(ast::block& block) override
     {
+        for (auto& stmt : block.statements())
+        {
+            stmt->accept(*this);
 
+            std::cout << "  " << stmt->to_string();
+            std::cout << linter_.cnf_.to_string() << "\n";
+        }
     }
 
     void process(ast::decl& decl) override
@@ -31,6 +41,7 @@ struct linter_visitor : public ast::statement_visitor
         // Hmm... So, when we declare variable, the replacement affects
         // the constraint set only if the variable was declared prior.
 
+        linter_.cnf_.add_var(decl.variable());
     }
 
     void process(ast::assign& assignment) override
@@ -51,7 +62,60 @@ struct linter_visitor : public ast::statement_visitor
         // Maybe: amend current address expressions
 
 
+        linter_.cnf_.add_var(alloc.destination_var());
 
+        const auto& currentVars = linter_.cnf_.current_vars();
+
+        static size_t tmpCount = 1;
+        auto tmpVar = linter_.astStore_.make_expression<ast::var>("@" + std::to_string(tmpCount++));
+
+
+        auto augmentedConstraints = linter_.cnf_;
+        augmentedConstraints.add_array_constraints_for(linter_.astStore_, tmpVar, alloc.alloc_size());
+
+        constraint::set newConstraints;
+        auto addrExprs = linter_.exprStat_.address_expressions();
+        for (size_t i = 0; i < addrExprs.size(); i++)
+        {
+            auto& e1 = addrExprs[i];
+            for (size_t j = i; j < addrExprs.size(); j++)
+            {
+                auto& e2 = addrExprs[j];
+
+                auto e1Replaced = ast::replace_var(linter_.astStore_, e1, alloc.destination_var(), tmpVar);
+                auto e2Replaced = ast::replace_var(linter_.astStore_, e2, alloc.destination_var(), tmpVar);
+
+                auto eq = linter_.astStore_.make_expression<ast::constraint>(
+                    ast::constraint::relation::eq, e1Replaced, e2Replaced
+                );
+
+                bool valid = augmentedConstraints.constraints().check_satisfiability_of(eq);
+                std::cout << "      Trying to prove " << eq->to_string() << " :: " << std::boolalpha << valid << '\n';
+                if (valid)
+                {
+                    newConstraints.add(linter_.astStore_.make_expression<ast::constraint>(
+                        ast::constraint::relation::eq, e1, e2
+                    ));
+                    continue;
+                }
+
+                auto neq = linter_.astStore_.make_expression<ast::constraint>(
+                    ast::constraint::relation::neq, e1Replaced, e2Replaced
+                );
+
+                valid = augmentedConstraints.constraints().check_satisfiability_of(neq);
+                std::cout << "      Trying to prove " << neq->to_string() << " :: " << std::boolalpha << valid << '\n';
+                if (valid)
+                {
+                    newConstraints.add(linter_.astStore_.make_expression<ast::constraint>(
+                        ast::constraint::relation::neq, e1, e2
+                    ));
+                    continue;
+                }
+            }
+        }
+
+        linter_.cnf_.constraints(newConstraints);
     }
 
     void process(ast::store&) override
@@ -69,6 +133,11 @@ struct linter_visitor : public ast::statement_visitor
         // Check if in current address variables
 
         // Required: remove var...
+        bool removed = linter_.cnf_.remove_var(dispose.target_var());
+        if (!removed)
+        {
+            std::cout << "!!!!!!!!!!!!!!!! Double free of " << dispose.target_var()->name() << "\n";
+        }
     }
 
     void process(ast::if_else&) override
@@ -88,6 +157,20 @@ private:
 void linter::process(ast::block& block)
 {
     block.accept(exprStat_);
+
+    std::cout << "ADDR VARS: ";
+    for (auto& v : exprStat_.address_variables())
+    {
+        std::cout << v->to_string() << " ";
+    }
+
+    std::cout << "\nADDR EXPRS: ";
+    for (auto& e : exprStat_.address_expressions())
+    {
+        std::cout << e->to_string() << ", ";
+    }
+
+    std::cout << "\n------\n";
 
     linter_visitor v(*this);
     block.accept(v);

--- a/src/linter/linter.hpp
+++ b/src/linter/linter.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <memory>
-
+#include <ast/manager.hpp>
 #include <ast/statements.hpp>
 #include <ast/expressions.hpp>
+#include <constraint/set.hpp>
 #include <linter/address_expr_collector.hpp>
 
 namespace linter
@@ -12,7 +12,7 @@ namespace linter
 struct linter
 {
     explicit linter(ast::manager& store) :
-        astStore_(store)
+        astStore_(store), exprStat_(store)
     {}
 
     const std::vector<std::string>& warnings() const
@@ -20,15 +20,12 @@ struct linter
         return diagnostics_;
     }
 
-    void process(ast::block& block)
-    {
-        address_expr_collector collector(astStore_);
-        block.accept(collector);
-    }
+    void process(ast::block& block);
 
 private:
     ast::manager& astStore_;
     std::vector<std::string> diagnostics_;
+    address_expr_collector exprStat_;
 };
 
 }

--- a/src/linter/linter.hpp
+++ b/src/linter/linter.hpp
@@ -5,6 +5,10 @@
 #include <ast/expressions.hpp>
 #include <constraint/set.hpp>
 #include <linter/address_expr_collector.hpp>
+#include <linter/configuration.hpp>
+
+#include <set>
+#include <vector>
 
 namespace linter
 {
@@ -26,6 +30,11 @@ private:
     ast::manager& astStore_;
     std::vector<std::string> diagnostics_;
     address_expr_collector exprStat_;
+
+    // Our only configuration for now
+    configuration cnf_;
+
+    friend struct linter_visitor;
 };
 
 }

--- a/src/linter/linter.test.cpp
+++ b/src/linter/linter.test.cpp
@@ -1,3 +1,5 @@
+#include <boost/ut.hpp>
+
 #include <linter/linter.hpp>
 #include <ast/manager.hpp>
 #include <ast/statements.hpp>
@@ -5,9 +7,22 @@
 #include <linter/linter.hpp>
 #include <iostream>
 
+using namespace boost::ut;
+
 int main()
 {
     ast::manager store;
+
+    auto testOn = [&store](std::string name, ast::block& block) {
+        test(name) = [&]() {
+            std::cout << "#######\n";
+            std::cout << "RUNNING " << name << "\n";
+            std::cout << "####### \n\n";
+
+            linter::linter linter(store);
+            linter.process(block);
+        };
+    };
 
     auto empty =
         ast::block(store,
@@ -25,9 +40,18 @@ int main()
             ast::dispose(store, "y")
         );
 
-    linter::linter linter(store);
+    auto directDoubleDispose =
+        ast::block(store,
+            ast::alloc(store, "x", 2),
+            ast::store(store, ast::var(store, "x"), ast::integer(store, 1)),
+            ast::store(store, ast::add(store, ast::var(store, "x"), ast::integer(store, 1)), ast::integer(store, 3)),
 
-    linter.process(empty);
+            ast::dispose(store, "x"),
+            ast::dispose(store, "x")
+        );
+
+    testOn("empty", empty);
+    testOn("direct_double_dispose", directDoubleDispose);
 
     return 0;
 }

--- a/src/linter/linter.test.cpp
+++ b/src/linter/linter.test.cpp
@@ -17,6 +17,7 @@ int main()
         test(name) = [&]() {
             std::cout << "#######\n";
             std::cout << "RUNNING " << name << "\n";
+            std::cout << block.to_string();
             std::cout << "####### \n\n";
 
             linter::linter linter(store);
@@ -50,8 +51,34 @@ int main()
             ast::dispose(store, "x")
         );
 
+    auto indirectDoubleDispose =
+        ast::block(store,
+            ast::alloc(store, "x", 2),
+            ast::store(store, ast::var(store, "x"), ast::integer(store, 1)),
+            ast::store(store, ast::add(store, ast::var(store, "x"), ast::integer(store, 1)), ast::integer(store, 3)),
+
+            ast::decl(store, "y", ast::integer(store, 0)),
+            ast::assign(store, "y", ast::var(store, "x")),
+
+            ast::dispose(store, "x"),
+            ast::dispose(store, "y")
+        );
+
+    auto overwrite =
+        ast::block(store,
+            ast::alloc(store, "x", 2),
+            ast::store(store, ast::var(store, "x"), ast::integer(store, 1)),
+            ast::store(store, ast::add(store, ast::var(store, "x"), ast::integer(store, 1)), ast::integer(store, 3)),
+
+            ast::assign(store, "x", ast::integer(store, 0)),
+
+            ast::dispose(store, "x")
+        );
+
     testOn("empty", empty);
     testOn("direct_double_dispose", directDoubleDispose);
+    testOn("indirect_double_dispose", indirectDoubleDispose);
+    testOn("overwrite", overwrite);
 
     return 0;
 }

--- a/src/linter/linter.test.cpp
+++ b/src/linter/linter.test.cpp
@@ -2,6 +2,7 @@
 #include <ast/manager.hpp>
 #include <ast/statements.hpp>
 #include <ast/expressions.hpp>
+#include <linter/linter.hpp>
 #include <iostream>
 
 int main()
@@ -24,8 +25,9 @@ int main()
             ast::dispose(store, "y")
         );
 
+    linter::linter linter(store);
 
-    std::cout << "Program:\n" << empty.to_string() << "\n\nLinter:\n";
+    linter.process(empty);
 
     return 0;
 }

--- a/src/linter/linter.test.cpp
+++ b/src/linter/linter.test.cpp
@@ -6,11 +6,16 @@
 #include <ast/expressions.hpp>
 #include <linter/linter.hpp>
 #include <iostream>
+#include <spdlog/common.h>
+#include <spdlog/spdlog.h>
 
 using namespace boost::ut;
 
 int main()
 {
+    spdlog::set_pattern("%H:%M:%S %^%l%$ %v");
+    spdlog::set_level(spdlog::level::trace);
+
     ast::manager store;
 
     auto testOn = [&store](std::string name, ast::block& block) {

--- a/src/linter/linter.test.cpp
+++ b/src/linter/linter.test.cpp
@@ -14,7 +14,7 @@ using namespace boost::ut;
 int main()
 {
     spdlog::set_pattern("%H:%M:%S %^%l%$ %v");
-    spdlog::set_level(spdlog::level::trace);
+    spdlog::set_level(spdlog::level::debug);
 
     ast::manager store;
 
@@ -69,6 +69,19 @@ int main()
             ast::dispose(store, "y")
         );
 
+    /*
+    auto disposeUnallocated =
+        ast::block(store,
+            ast::decl(store, "x", 0),
+            ast::store(store, ast::var(store, "x"), ast::integer(store, 1)),
+            ast::store(store, ast::add(store, ast::var(store, "x"), ast::integer(store, 1)), ast::integer(store, 3)),
+
+            ast::assign(store, "x", ast::integer(store, 0)),
+
+            ast::dispose(store, "x")
+        );
+        */
+
     auto overwrite =
         ast::block(store,
             ast::alloc(store, "x", 2),
@@ -80,10 +93,18 @@ int main()
             ast::dispose(store, "x")
         );
 
-    testOn("empty", empty);
-    testOn("direct_double_dispose", directDoubleDispose);
-    testOn("indirect_double_dispose", indirectDoubleDispose);
-    testOn("overwrite", overwrite);
+    struct test_case { std::string name; ast::block& code; };
+    std::vector<test_case> tests{
+        { "empty", empty },
+        { "direct_double_dispose", directDoubleDispose },
+        { "indirect_double_dispose", indirectDoubleDispose },
+        { "overwrite", overwrite },
+    };
+    
+    for (auto& t : tests)
+    {
+        testOn(t.name, t.code);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Resolves #4.